### PR TITLE
fix peeringdb API URL

### DIFF
--- a/lib/class/peeringdb.php
+++ b/lib/class/peeringdb.php
@@ -10,7 +10,7 @@ class PeeringDB {
 
   public function __construct() {
     global $peeringdb;
-    $this->url = 'https://peeringdb.com/api';
+    $this->url = 'https://www.peeringdb.com/api';
   }
 
   protected function sendRequest( $url ) {


### PR DESCRIPTION
The peeringdb API endpoint moved:

curl -v https://peeringdb.com/api -> 301 
curl -v https://www.peeringdb.com/api -> success
